### PR TITLE
Refactor gitkit, update CLI, add example.go

### DIFF
--- a/cmd/repofetch/repofetch.go
+++ b/cmd/repofetch/repofetch.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"log/slog"
 
@@ -59,6 +60,8 @@ func main() {
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, logOptions))
 	slog.SetDefault(logger)
+
+	slog.Debug("Running repofetch", "args", args, "options", opts)
 
 	token, err := getToken(opts)
 	if err != nil {
@@ -153,20 +156,47 @@ func fetchRepositories(client *gitkit.GitHubClient, paths []string, opts options
 	}
 
 	cloneOpts := gitkit.CloneOptions{
-		Depth:       opts.depth,
-		Concurrency: opts.concurrency,
-		Bare:        opts.bare,
+		Depth: opts.depth,
+		Bare:  opts.bare,
 	}
 
-	for _, path := range paths {
-		owner, repoName, err := gitkit.ExtractOwnerAndRepoName(path)
-		if err != nil {
-			return fmt.Errorf("failed to extract owner and repo name for path %s: %w", path, err)
-		}
+	var reposToClone []string
 
-		if err := client.CloneOrFetchAllRepos(owner, repoName, dir, cloneOpts); err != nil {
-			return fmt.Errorf("failed to clone or fetch repos for %s/%s: %w", owner, *repoName, err)
+	for _, path := range paths {
+		repos, err := client.GetRepositories(path)
+		if err != nil {
+			return fmt.Errorf("failed to list repositories for path %s: %w", path, err)
 		}
+		reposToClone = append(reposToClone, repos...)
+	}
+
+	sem := make(chan struct{}, opts.concurrency)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var errs []string
+
+	for _, repoURL := range reposToClone {
+		wg.Add(1)
+		sem <- struct{}{}
+
+		go func(repoURL string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			_, err := client.CloneOrFetchRepo(repoURL, dir, cloneOpts)
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Sprintf("failed to clone or fetch repo %s: %v", repoURL, err))
+				mu.Unlock()
+			}
+		}(repoURL)
+	}
+
+	wg.Wait()
+	close(sem)
+
+	if len(errs) > 0 {
+		return fmt.Errorf("encountered errors: \n%s", strings.Join(errs, "\n"))
 	}
 
 	return nil

--- a/cmd/repofetch/repofetch.go
+++ b/cmd/repofetch/repofetch.go
@@ -183,7 +183,7 @@ func fetchRepositories(client *gitkit.GitHubClient, paths []string, opts options
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			_, err := client.CloneOrFetchRepo(repoURL, dir, &cloneOpts)
+			_, err := client.CloneOrFetchRepo(repoURL, dir, &cloneOpts, nil)
 			if err != nil {
 				mu.Lock()
 				errs = append(errs, fmt.Sprintf("failed to clone or fetch repo %s: %v", repoURL, err))

--- a/cmd/repofetch/repofetch.go
+++ b/cmd/repofetch/repofetch.go
@@ -183,7 +183,7 @@ func fetchRepositories(client *gitkit.GitHubClient, paths []string, opts options
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			_, err := client.CloneOrFetchRepo(repoURL, dir, cloneOpts)
+			_, err := client.CloneOrFetchRepo(repoURL, dir, &cloneOpts)
 			if err != nil {
 				mu.Lock()
 				errs = append(errs, fmt.Sprintf("failed to clone or fetch repo %s: %v", repoURL, err))

--- a/gitkit/example/example.go
+++ b/gitkit/example/example.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/supply-chain-tools/go-sandbox/gitkit"
+)
+
+func main() {
+	repoPaths := []string{
+		"github.com/torvalds", // all repos for user/org
+		"https://github.com/golang/go",
+		"github.com/kubernetes/kubernetes.git",
+	}
+
+	client := gitkit.NewGitHubClient()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		fmt.Printf("Error getting current directory: %v\n", err)
+		return
+	}
+
+	var outputBuffer bytes.Buffer
+	progressWriter := io.Writer(&outputBuffer)
+
+	cloneOpts := gitkit.CloneOptions{
+		// Depth:    1,
+		Bare:     false,
+		Progress: &progressWriter,
+	}
+
+	// monitor output buffer and print updates
+	done := make(chan bool)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				if outputBuffer.Len() > 0 {
+					fmt.Print(outputBuffer.String())
+					outputBuffer.Reset() // clear buffer on print
+				}
+				time.Sleep(20 * time.Millisecond) // avoid busy loop
+			}
+		}
+	}()
+
+	for _, path := range repoPaths {
+		repos, err := client.GetRepositories(path)
+		if err != nil {
+			fmt.Printf("Failed to list repositories for path %s: %v\n", path, err)
+			continue
+		}
+
+		for _, repoURL := range repos {
+			fmt.Printf("Cloning repository: %s\n", repoURL)
+			result, err := client.CloneOrFetchRepo(repoURL, dir, cloneOpts)
+			if err != nil {
+				fmt.Printf("Error cloning repository %s: %v\n", repoURL, err)
+			} else {
+				fmt.Println("Result:", result)
+			}
+		}
+
+		done <- true
+		time.Sleep(100 * time.Millisecond) // wait for last print
+	}
+}

--- a/gitkit/example/example.go
+++ b/gitkit/example/example.go
@@ -31,7 +31,7 @@ func main() {
 	cloneOpts := gitkit.CloneOptions{
 		// Depth:    1,
 		Bare:     false,
-		Progress: &progressWriter,
+		Progress: progressWriter,
 	}
 
 	// monitor output buffer and print updates
@@ -60,7 +60,7 @@ func main() {
 
 		for _, repoURL := range repos {
 			fmt.Printf("Cloning repository: %s\n", repoURL)
-			result, err := client.CloneOrFetchRepo(repoURL, dir, cloneOpts)
+			result, err := client.CloneOrFetchRepo(repoURL, dir, &cloneOpts)
 			if err != nil {
 				fmt.Printf("Error cloning repository %s: %v\n", repoURL, err)
 			} else {

--- a/gitkit/github.go
+++ b/gitkit/github.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -230,10 +231,9 @@ func (gc *GitHubClient) CloneOrFetchRepo(repoURL string, localBasePath string, o
 	var result CloneResult
 	var progress io.Writer
 
-	// set writer and discard if nil
+	// set default writer
 	if opts.Progress == nil {
-		discard := io.Discard
-		progress = discard
+		progress = os.Stdout
 	} else {
 		progress = *opts.Progress
 	}

--- a/gitkit/github.go
+++ b/gitkit/github.go
@@ -3,16 +3,15 @@ package gitkit
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/google/go-github/v61/github"
-	"log"
-	"log/slog"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
 )
 
 type GitHubClient struct {
@@ -36,10 +35,18 @@ func NewGitHubClient() *GitHubClient {
 	}
 }
 
+type CloneResult struct {
+	RepoName  string
+	RepoURL   string
+	LocalPath string
+	Status    string
+	Error     error
+}
+
 type CloneOptions struct {
-	Depth       int
-	Concurrency int
-	Bare        bool
+	Depth    int
+	Bare     bool
+	Progress *io.Writer
 }
 
 func (gc *GitHubClient) GetGitHubOrganization(org string) (info *github.Organization, found bool, err error) {
@@ -140,8 +147,117 @@ func (gc *GitHubClient) ListAllReposForUser(user string) ([]*github.Repository, 
 	return repos, nil
 }
 
-func (gc *GitHubClient) CloneOrFetchGitHubToPath(org string, repoName string, path string, opts *CloneOptions) error {
-	fmt.Printf("Cloning '%s/%s'\n", org, repoName)
+func (gc *GitHubClient) GetRepositories(url string) ([]string, error) {
+	// remove .git suffix if present
+	url = strings.TrimSuffix(url, ".git")
+
+	// owner and repo
+	owner, repoName, err := ExtractOwnerAndRepoName(url)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL '%s': %w", url, err)
+	}
+
+	// org
+	orgInfo, res, err := gc.client.Organizations.Get(context.Background(), owner)
+	isOrg := res != nil && res.StatusCode == 200
+	if err != nil && (res == nil || res.StatusCode != 404) {
+		return nil, fmt.Errorf("error fetching organization info: %w", err)
+	}
+
+	// user
+	userInfo, res, err := gc.client.Users.Get(context.Background(), owner)
+	isUser := res != nil && res.StatusCode == 200
+	if err != nil && (res == nil || res.StatusCode != 404) {
+		return nil, fmt.Errorf("error fetching user info: %w", err)
+	}
+
+	if !(isOrg || isUser) {
+		return nil, fmt.Errorf("no user or organization named '%s'", owner)
+	}
+
+	// owner is same as actual owner
+	if isOrg {
+		if strings.ToLower(owner) != strings.ToLower(*orgInfo.Login) {
+			return nil, fmt.Errorf("actual '%s' and requested '%s' org differ in more than casing", *orgInfo.Login, owner)
+		}
+		owner = *orgInfo.Login
+	} else {
+		if strings.ToLower(owner) != strings.ToLower(*userInfo.Login) {
+			return nil, fmt.Errorf("actual '%s' and requested '%s' user differ in more than casing", *orgInfo.Login, owner)
+		}
+		owner = *userInfo.Login
+	}
+
+	var repoURLs []string
+
+	if repoName == nil { // all repos
+		var repos []*github.Repository
+		if isOrg {
+			repos, err = gc.ListAllReposForOrg(owner)
+		} else {
+			repos, err = gc.ListAllReposForUser(owner)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error listing repositories: %w", err)
+		}
+
+		for _, repo := range repos {
+			repoURLs = append(repoURLs, fmt.Sprintf("https://github.com/%s/%s.git", owner, repo.GetName()))
+		}
+	} else { // single repo
+		if *repoName == "" {
+			return nil, fmt.Errorf("repository name must not be empty")
+		}
+
+		repoInfo, found, err := gc.GetGitHubRepo(owner, *repoName)
+		if err != nil {
+			return nil, fmt.Errorf("error fetching repository '%s/%s': %w", owner, *repoName, err)
+		}
+		if !found {
+			return nil, fmt.Errorf("repository '%s/%s' not found", owner, *repoName)
+		}
+		if !strings.EqualFold(*repoInfo.Name, *repoName) {
+			return nil, fmt.Errorf("actual '%s' and requested '%s' repo differ in more than casing", *repoInfo.Name, *repoName)
+		}
+
+		repoURLs = append(repoURLs, fmt.Sprintf("https://github.com/%s/%s.git", owner, *repoName))
+	}
+
+	return repoURLs, nil
+}
+
+func (gc *GitHubClient) CloneOrFetchRepo(repoURL string, localBasePath string, opts CloneOptions) (CloneResult, error) {
+	var result CloneResult
+	var progress io.Writer
+
+	// set writer and discard if nil
+	if opts.Progress == nil {
+		discard := io.Discard
+		progress = discard
+	} else {
+		progress = *opts.Progress
+	}
+
+	// ensure scheme
+	if !strings.HasPrefix(repoURL, "https://") && !strings.HasPrefix(repoURL, "http://") {
+		repoURL = "https://" + repoURL
+	}
+
+	// get owner and repo
+	owner, repoName, err := ExtractOwnerAndRepoName(repoURL)
+	if err != nil {
+		return result, fmt.Errorf("invalid URL '%s': %w", repoURL, err)
+	}
+
+	// create owner directory
+	repoPath := filepath.Join(localBasePath, owner, *repoName)
+	result = CloneResult{
+		RepoName:  *repoName,
+		RepoURL:   repoURL,
+		LocalPath: repoPath,
+	}
+
+	fmt.Fprintf(progress, "Cloning '%s/%s' into '%s'\n", owner, *repoName, repoPath)
 
 	var auth transport.AuthMethod = nil
 	if gc.token != nil {
@@ -153,194 +269,56 @@ func (gc *GitHubClient) CloneOrFetchGitHubToPath(org string, repoName string, pa
 
 	cloneOptions := &git.CloneOptions{
 		Auth:     auth,
-		URL:      "https://github.com/" + org + "/" + repoName,
-		Progress: os.Stdout,
+		URL:      repoURL,
+		Progress: *opts.Progress,
 		Depth:    opts.Depth,
 	}
 
 	fetchOptions := &git.FetchOptions{
 		RemoteName: "origin",
 		Auth:       auth,
-		Progress:   os.Stdout,
+		Progress:   *opts.Progress,
 		Prune:      true,
 		Depth:      opts.Depth,
 	}
 
-	var err error
-	if opts.Bare {
-		_, err = git.PlainClone(path+".git", true, cloneOptions)
-	} else {
-		_, err = git.PlainClone(path, false, cloneOptions)
-	}
+	repo, err := git.PlainOpen(repoPath)
+	if err == nil { // repo exists, fetch updates
+		fmt.Fprintf(progress, "Repository '%s/%s' exists. Fetching updates...\n", owner, *repoName)
 
-	if err != nil {
-		errorString := err.Error()
-		if errorString == "repository already exists" {
-			fmt.Printf("Updating\n")
-			repo, err := git.PlainOpen(path)
-			if err != nil {
-				return fmt.Errorf("unable to open git repository '%s': %w", path, err)
-			}
-
-			err = repo.Fetch(fetchOptions)
-			if err != nil && err.Error() != "already up-to-date" && err.Error() != "remote repository is empty" {
-				return fmt.Errorf("unable to fetch repo '%s': %w", path, err)
-			}
-		} else if errorString != "remote repository is empty" {
-			// FIXME better tracking of failed repos
-			// https://stackoverflow.com/a/57733557
-			log.Printf("warning skipping repo '%s/%s' due to error '%s'", org, repoName, errorString)
-		}
-	}
-
-	return nil
-}
-
-func (gc *GitHubClient) CloneOrFetchAllRepos(owner string, repoName *string, localBasePath string, opts CloneOptions) error {
-	orgInfo, isOrg, err := gc.GetGitHubOrganization(owner)
-	if err != nil {
-		return err
-	}
-
-	userInfo, isUser, err := gc.GetGitHubUser(owner)
-	if err != nil {
-		return err
-	}
-
-	if !(isOrg || isUser) {
-		return fmt.Errorf("no user or org named %s", owner)
-	}
-
-	if isOrg {
-		if strings.ToLower(owner) != strings.ToLower(*orgInfo.Login) {
-			return fmt.Errorf("actual '%s' and requested '%s' org differ in more than casing", *orgInfo.Login, owner)
-		}
-		owner = *orgInfo.Login
-	} else {
-		if strings.ToLower(owner) != strings.ToLower(*userInfo.Login) {
-			return fmt.Errorf("actual '%s' and requested '%s' user differ in more than casing", *orgInfo.Login, owner)
-		}
-		owner = *userInfo.Login
-	}
-
-	ownerPath, err := createDirectoryIfNotExists(localBasePath, owner)
-	if err != nil {
-		return err
-	}
-
-	if repoName == nil {
-		var allRepos []*github.Repository
-		var ownerType string
-		if isOrg {
-			ownerType = "organization"
-			allRepos, err = gc.ListAllReposForOrg(owner)
-			if err != nil {
-				return err
-			}
-		} else {
-			ownerType = "user"
-			allRepos, err = gc.ListAllReposForUser(owner)
-			if err != nil {
-				return err
+		err = repo.Fetch(fetchOptions)
+		if err != nil {
+			if err != git.NoErrAlreadyUpToDate && err.Error() != "remote repository is empty" {
+				result.Error = fmt.Errorf("unable to fetch repo '%s': %v", *repoName, err)
+				slog.Debug(result.Error.Error())
+				return result, result.Error
 			}
 		}
-
-		logFields := []interface{}{
-			"owner", owner,
-			"ownerType", ownerType,
-			"numberOfRepos", len(allRepos),
-			"concurrency", opts.Concurrency,
-			"depth", opts.Depth,
-		}
-
+		result.Status = "Fetched"
+		slog.Debug("Fetch completed", "repoName", *repoName, "path", repoPath)
+	} else if err == git.ErrRepositoryNotExists { // repo does not exist, clone
+		slog.Debug("Cloning repository", "url", repoURL, "repoName", *repoName, "path", repoPath)
 		if opts.Bare {
-			logFields = append(logFields, "bare", true)
-		}
-
-		slog.Debug("cloning/fetching", logFields...)
-
-		sem := make(chan struct{}, opts.Concurrency)
-		var wg sync.WaitGroup
-
-		for _, r := range allRepos {
-			wg.Add(1)
-			sem <- struct{}{}
-
-			go func(repo *github.Repository) {
-				defer wg.Done()
-				defer func() { <-sem }()
-
-				fmt.Println("Cloning", repo.GetName())
-
-				repoPath := filepath.Join(ownerPath, repo.GetName())
-				err := gc.CloneOrFetchGitHubToPath(owner, repo.GetName(), repoPath, &opts)
-				if err != nil {
-					log.Printf("Error cloning repo %s/%s: %v", owner, repo.GetName(), err)
-				}
-			}(r)
-		}
-
-		wg.Wait()
-
-	} else {
-		if *repoName == "" {
-			return fmt.Errorf("repo name must not be empty string")
-		}
-
-		repoInfo, found, err := gc.GetGitHubRepo(owner, *repoName)
-		if err != nil {
-			return err
-		}
-
-		if !found {
-			return fmt.Errorf("repository '%s/%s' not found\n", owner, *repoName)
-		}
-
-		if strings.ToLower(*repoInfo.Name) != strings.ToLower(*repoName) {
-			return fmt.Errorf("actual '%s' and requested '%s' repo differ in more than casing", *repoInfo.Name, *repoName)
-		}
-		*repoName = *repoInfo.Name
-
-		var ownerType string
-		if isOrg {
-			ownerType = "organization"
+			_, err = git.PlainClone(repoPath+".git", true, cloneOptions)
 		} else {
-			ownerType = "user"
+			_, err = git.PlainClone(repoPath, false, cloneOptions)
 		}
 
-		slog.Debug("cloning/fetching",
-			"owner", owner,
-			"ownerType", ownerType,
-			"repoName", repoName)
-
-		repoPath := filepath.Join(ownerPath, *repoName)
-		err = gc.CloneOrFetchGitHubToPath(owner, *repoName, repoPath, &opts)
-		if err != nil {
-			return err
+		if err == nil {
+			result.Status = "Cloned"
+			slog.Debug("Successfully cloned", "url", repoURL, "repoName", *repoName, "path", repoPath)
+		} else {
+			result.Error = fmt.Errorf("error cloning repo '%s/%s': %v", owner, *repoName, err)
+			slog.Debug(result.Error.Error())
+			return result, result.Error
 		}
+	} else {
+		result.Error = fmt.Errorf("error accessing repository '%s/%s': %v", owner, *repoName, err)
+		slog.Debug(result.Error.Error())
+		return result, result.Error
 	}
 
-	return nil
-}
-
-func createDirectoryIfNotExists(basePath string, relativePath string) (string, error) {
-	path := filepath.Join(basePath, relativePath)
-	stat, err := os.Stat(path)
-	if err != nil && os.IsNotExist(err) {
-		err := os.Mkdir(path, os.ModePerm)
-		if err != nil {
-			return "", err
-		}
-		return path, nil
-	} else if err != nil {
-		return "", err
-	}
-
-	if !stat.IsDir() {
-		return "", fmt.Errorf("path '%s' exists but is not a directory", path)
-	}
-
-	return path, nil
+	return result, nil
 }
 
 func ExtractOwnerAndRepoName(input string) (owner string, repoName *string, err error) {

--- a/gitkit/github.go
+++ b/gitkit/github.go
@@ -149,23 +149,19 @@ func (gc *GitHubClient) ListAllReposForUser(user string) ([]*github.Repository, 
 }
 
 func (gc *GitHubClient) GetRepositories(url string) ([]string, error) {
-	// remove .git suffix if present
 	url = strings.TrimSuffix(url, ".git")
 
-	// owner and repo
 	owner, repoName, err := ExtractOwnerAndRepoName(url)
 	if err != nil {
 		return nil, fmt.Errorf("invalid URL '%s': %w", url, err)
 	}
 
-	// org
 	orgInfo, res, err := gc.client.Organizations.Get(context.Background(), owner)
 	isOrg := res != nil && res.StatusCode == 200
 	if err != nil && (res == nil || res.StatusCode != 404) {
 		return nil, fmt.Errorf("error fetching organization info: %w", err)
 	}
 
-	// user
 	userInfo, res, err := gc.client.Users.Get(context.Background(), owner)
 	isUser := res != nil && res.StatusCode == 200
 	if err != nil && (res == nil || res.StatusCode != 404) {
@@ -176,7 +172,6 @@ func (gc *GitHubClient) GetRepositories(url string) ([]string, error) {
 		return nil, fmt.Errorf("no user or organization named '%s'", owner)
 	}
 
-	// owner is same as actual owner
 	if isOrg {
 		if strings.ToLower(owner) != strings.ToLower(*orgInfo.Login) {
 			return nil, fmt.Errorf("actual '%s' and requested '%s' org differ in more than casing", *orgInfo.Login, owner)
@@ -231,25 +226,21 @@ func (gc *GitHubClient) CloneOrFetchRepo(repoURL string, localBasePath string, o
 	var result CloneResult
 	var progress io.Writer
 
-	// set default writer
 	if opts.Progress == nil {
-		progress = os.Stdout
+		progress = os.Stdout // default to stdout
 	} else {
 		progress = *opts.Progress
 	}
 
-	// ensure scheme
 	if !strings.HasPrefix(repoURL, "https://") && !strings.HasPrefix(repoURL, "http://") {
 		repoURL = "https://" + repoURL
 	}
 
-	// get owner and repo
 	owner, repoName, err := ExtractOwnerAndRepoName(repoURL)
 	if err != nil {
 		return result, fmt.Errorf("invalid URL '%s': %w", repoURL, err)
 	}
 
-	// create owner directory
 	repoPath := filepath.Join(localBasePath, owner, *repoName)
 	result = CloneResult{
 		RepoName:  *repoName,

--- a/gitkit/github.go
+++ b/gitkit/github.go
@@ -330,7 +330,7 @@ func ExtractOwnerAndRepoName(input string) (owner string, repoName *string, err 
 	} else if strings.HasPrefix(input, githubPrefix) {
 		userOrOrg = strings.TrimPrefix(input, githubPrefix)
 	} else {
-		return "", nil, fmt.Errorf("invalid target '%s'; must be prefixed with 'github.com/'", userOrOrg)
+		return "", nil, fmt.Errorf("invalid target '%s'; must start with '%s' or '%s", userOrOrg, httpsGithubPrefix, githubPrefix)
 	}
 
 	userOrOrg = strings.Trim(userOrOrg, "/")


### PR DESCRIPTION
Gitkit:
- Refactor clone functions to simplify API and clarity
- Decoupled concurrency handling from lib as API changes allow this to be managed at outer layer
- Cloning function now return `CloneResult` which also contain errors to track failed clones
- Support `io.Writer` option for polling clone/fetch progress
- Added `gitkit/example/example.go`

CLI:
- Now manages concurrency