### PR TITLE
Refactor repo fetching and cloning logic

### DIFF
--- a/cmd/repofetch/repofetch.go
+++ b/cmd/repofetch/repofetch.go
@@ -200,9 +200,9 @@ func fetchRepositories(client *gitkit.GitHubClient, uris []string, opts options)
 func validateAndNormalizeURI(gitHubURI string) (string, error) {
 	if strings.HasPrefix(gitHubURI, "github.com/") {
 		gitHubURI = "https://" + gitHubURI
-	} else if strings.HasPrefix(gitHubURI, "http://github.com/") {
-		gitHubURI = strings.Replace(gitHubURI, "http://", "https://", 1)
-	} else if !strings.HasPrefix(gitHubURI, "https://github.com/") {
+	}
+
+	if !strings.HasPrefix(gitHubURI, "https://github.com/") {
 		return "", fmt.Errorf("invalid URI '%s'; must be prefixed with 'https://github.com/' or 'github.com/'", gitHubURI)
 	}
 

--- a/gitkit/example/example.go
+++ b/gitkit/example/example.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/supply-chain-tools/go-sandbox/gitkit"
 )
@@ -16,12 +15,6 @@ func main() {
 
 	client := gitkit.NewGitHubClient()
 
-	dir, err := os.Getwd()
-	if err != nil {
-		fmt.Printf("Error getting current directory: %v\n", err)
-		return
-	}
-
 	for _, path := range repoPaths {
 		repos, err := client.GetRepositories(path)
 		if err != nil {
@@ -30,11 +23,9 @@ func main() {
 		}
 
 		for _, repoURL := range repos {
-			fmt.Printf("Cloning repository: %s\n", repoURL)
-
-			result, err := client.CloneOrFetchRepo(repoURL, dir, nil, nil)
+			result, err := client.CloneOrFetchRepo(repoURL, nil, nil)
 			if err != nil {
-				fmt.Printf("Error cloning repository %s: %v\n", repoURL, err)
+				fmt.Println("Error:", err)
 			} else {
 				fmt.Println("Result:", result)
 			}

--- a/gitkit/github_test.go
+++ b/gitkit/github_test.go
@@ -5,33 +5,33 @@ import (
 )
 
 func TestExtractOwnerAndRepoName(t *testing.T) {
-	owner, repoName, err := ExtractOwnerAndRepoName("github.com/Foo")
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		input     string
+		wantErr   bool
+		wantOwner string
+		wantRepo  *string
+	}{
+		{"github.com/Foo", true, "", nil},
+		{"http://github.com/Foo", true, "", nil},
+		{"https://github.com/Foo", false, "Foo", nil},
+		{"https://github.com/Foo/", false, "Foo", nil},
+		{"https://github.com/Foo/Bar", false, "Foo", &[]string{"Bar"}[0]},
 	}
 
-	if owner != "Foo" {
-		t.Errorf("want organization 'Foo', got '%s'", owner)
-	}
+	for _, tt := range tests {
+		owner, repoName, err := ExtractOwnerAndRepoName(tt.input)
+		if (err != nil) != tt.wantErr {
+			t.Fatalf("ExtractOwnerAndRepoName(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+		}
 
-	if repoName != nil {
-		t.Errorf("want empty repo name, got '%s'", *repoName)
-	}
+		if owner != tt.wantOwner {
+			t.Errorf("ExtractOwnerAndRepoName(%q) = owner %q, want %q", tt.input, owner, tt.wantOwner)
+		}
 
-	owner, repoName, err = ExtractOwnerAndRepoName("github.com/Foo/Bar")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if owner != "Foo" {
-		t.Errorf("want organization 'Foo', got '%s'", owner)
-	}
-
-	if repoName == nil {
-		t.Fatal("want repo name 'Bar', got nil")
-	}
-
-	if *repoName != "Bar" {
-		t.Errorf("want repo name 'Bar', got '%s'", *repoName)
+		if (repoName == nil) != (tt.wantRepo == nil) {
+			t.Errorf("ExtractOwnerAndRepoName(%q) = repoName %v, want %v", tt.input, repoName, tt.wantRepo)
+		} else if repoName != nil && *repoName != *tt.wantRepo {
+			t.Errorf("ExtractOwnerAndRepoName(%q) = repoName %q, want %q", tt.input, *repoName, *tt.wantRepo)
+		}
 	}
 }


### PR DESCRIPTION
- Split logic into Clone and Fetch functions for flexibility
- Moved local path handling into Clone/Fetch functions
- Renamed CloneResult to GitResult for consistency
- Replaced `Signal` with `GitCommand` in GitResult to distinguish between Clone and Fetch
- Added utility functions to reduce duplication and centralize logic
- Minor improvements to CLI output
- Added user input validation / normalization
- Lib clone functions now expect https scheme
- Improved logging