### PR TITLE
Include protected branches in `after-candidates`

### DIFF
--- a/cmd/gitverify/gitverify.go
+++ b/cmd/gitverify/gitverify.go
@@ -319,6 +319,10 @@ func verify(opts *VerifyOptions) error {
 
 	var repoConfig *gitverify.RepoConfig
 	repoConfig, repoUri, err = loadRepoConfig(repo, configFilePath, repoUri)
+	if err != nil {
+		return errr
+	}
+
 	err = gitverify.Verify(repo, state, repoConfig, sha1Hash, sha256Hash, validateOptions)
 	if err != nil {
 		return err

--- a/cmd/gitverify/gitverify.go
+++ b/cmd/gitverify/gitverify.go
@@ -48,6 +48,10 @@ VERIFY OPTIONS
                 verify that head points to the --branch.
 
 AFTER-CANDIDATES OPTIONS
+        --config-file
+                Config file to use.
+        --repository-uri
+                URI to the repository in the config file.
         --sha256
                 Output SHA-256 hashes in addition to SHA-1.
 

--- a/cmd/gitverify/gitverify.go
+++ b/cmd/gitverify/gitverify.go
@@ -320,7 +320,7 @@ func verify(opts *VerifyOptions) error {
 	var repoConfig *gitverify.RepoConfig
 	repoConfig, repoUri, err = loadRepoConfig(repo, configFilePath, repoUri)
 	if err != nil {
-		return errr
+		return err
 	}
 
 	err = gitverify.Verify(repo, state, repoConfig, sha1Hash, sha256Hash, validateOptions)

--- a/gitverify/after_candidates.go
+++ b/gitverify/after_candidates.go
@@ -8,9 +8,10 @@ import (
 	"github.com/supply-chain-tools/go-sandbox/githash"
 	"github.com/supply-chain-tools/go-sandbox/gitkit"
 	"github.com/supply-chain-tools/go-sandbox/hashset"
+	"strings"
 )
 
-func AfterCandidates(repo *git.Repository, useSHA256 bool) ([]After, error) {
+func AfterCandidates(repo *git.Repository, repoConfig *RepoConfig, useSHA256 bool) ([]After, error) {
 	state := gitkit.LoadRepoState(repo)
 	sha256Hash := githash.NewGitHashFromRepoState(state, sha256.New())
 
@@ -22,20 +23,68 @@ func AfterCandidates(repo *git.Repository, useSHA256 bool) ([]After, error) {
 		}
 	}
 
+	remotes, err := repo.References()
+	if err != nil {
+		return nil, err
+	}
+
 	candidates := make([]After, 0)
+	protectedHashes := hashset.New[plumbing.Hash]()
+
+	err = remotes.ForEach(func(reference *plumbing.Reference) error {
+		if !strings.HasPrefix(reference.Name().String(), "refs/remotes/origin/") {
+			// local branches might not be up-to-date, so using remotes/origin
+			return nil
+		}
+
+		isProtected, branchName := isProtected(reference, repoConfig)
+
+		if isProtected {
+			sha1 := reference.Hash().String()
+			var hexSHA256 *string = nil
+
+			if useSHA256 {
+				sha2, err := sha256Hash.CommitSum(reference.Hash())
+				if err != nil {
+					return err
+				}
+
+				h := hex.EncodeToString(sha2)
+				hexSHA256 = &h
+			}
+
+			candidates = append(candidates, After{
+				SHA1:   &sha1,
+				SHA256: hexSHA256,
+				Branch: &branchName,
+			})
+
+			protectedHashes.Add(reference.Hash())
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	for _, commit := range state.CommitMap {
 		if !pointedTo.Contains(commit.Hash) {
 
 			sha1 := commit.Hash.String()
 
+			if protectedHashes.Contains(commit.Hash) {
+				continue
+			}
+
 			var hexSHA256 *string = nil
 			if useSHA256 {
-				sha256, err := sha256Hash.CommitSum(commit.Hash)
+				sha2, err := sha256Hash.CommitSum(commit.Hash)
 				if err != nil {
 					return nil, err
 				}
 
-				h := hex.EncodeToString(sha256)
+				h := hex.EncodeToString(sha2)
 				hexSHA256 = &h
 			}
 


### PR DESCRIPTION
The protected branches are required to be present
in `after` so always include them even if there
are more recent commits.

Fixes #35 